### PR TITLE
fix: removed `sendMessage` from `EquitoApp`

### DIFF
--- a/src/EquitoApp.sol
+++ b/src/EquitoApp.sol
@@ -55,24 +55,6 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
         }
     }
 
-    /// @notice Sends a cross-chain message using Equito.
-    /// @param receiver The address of the receiver.
-    /// @param destinationChainSelector The identifier of the destination chain.
-    /// @param data The message data.
-    /// @return The message ID.
-    function sendMessage(
-        bytes64 calldata receiver,
-        uint256 destinationChainSelector,
-        bytes calldata data
-    ) external payable returns (bytes32) {
-        return
-            router.sendMessage{value: msg.value}(
-                receiver,
-                destinationChainSelector,
-                data
-            );
-    }
-
     /// @notice Receives a cross-chain message from the Router Contract.
     ///         It is a wrapper function for the `_receiveMessage` function, that needs to be overridden.
     ///         Only the Router Contract is allowed to call this function.

--- a/src/examples/CrossChainSwap.sol
+++ b/src/examples/CrossChainSwap.sol
@@ -63,7 +63,6 @@ contract CrossChainSwap is EquitoApp {
         uint256 destinationChainSelector,
         bytes memory destinationToken
     ) public view returns (uint256) {
-        IRouter router = IRouter(router);
         return
             (amount * tokenPrice[router.chainSelector()][sourceToken]) /
             tokenPrice[destinationChainSelector][destinationToken];
@@ -201,9 +200,6 @@ contract CrossChainSwap is EquitoApp {
             destinationChainSelector,
             destinationToken
         );
-
-        // Initialize a router client instance to interact with cross-chain router
-        IRouter router = IRouter(router);
 
         TokenAmount memory tokenAmount = TokenAmount({
             token: destinationToken,

--- a/src/examples/PingPong.sol
+++ b/src/examples/PingPong.sol
@@ -46,7 +46,11 @@ contract PingPong is EquitoApp {
         bytes memory data = abi.encode("ping", message);
         bytes64 memory receiver = peers[destinationChainSelector];
 
-        bytes32 messageHash = this.sendMessage(receiver, destinationChainSelector, data);
+        bytes32 messageHash = router.sendMessage{value: msg.value}(
+            receiver, 
+            destinationChainSelector, 
+            data
+            );
         emit PingSent(destinationChainSelector, messageHash);
     }
 
@@ -73,7 +77,11 @@ contract PingPong is EquitoApp {
         bytes memory data = abi.encode("pong", message);
         bytes64 memory receiver = peers[destinationChainSelector];
 
-        bytes32 messageHash = this.sendMessage(receiver, destinationChainSelector, data);
+        bytes32 messageHash = router.sendMessage{value: msg.value}(
+            receiver, 
+            destinationChainSelector, 
+            data
+        );
         emit PongSent(destinationChainSelector, messageHash);
     }
 }

--- a/test/EquitoApp.t.sol
+++ b/test/EquitoApp.t.sol
@@ -31,22 +31,6 @@ contract EquitoAppTest is Test {
         vm.stopPrank();
     }
 
-    function testSendMessage() public {
-        bytes64 memory receiverAddress = EquitoMessageLibrary.addressToBytes64(
-            address(app)
-        );
-        uint256 destinationChainSelector = 2;
-        bytes memory data = hex"123456";
-
-        bytes32 messageHash = app.sendMessage(
-            receiverAddress,
-            destinationChainSelector,
-            data
-        );
-
-        assertTrue(messageHash != bytes32(0), "Message ID should not be zero");
-    }
-
     /// @dev Tests the onlyRouter modifier
     function testOnlyRouterModifier() public {
         vm.prank(ALICE);


### PR DESCRIPTION
Being `external`, `sendMessage` was callable by any account, allowing to forge messages which would appear as sent by the `EquitoApp`.
Since `internal` (and `private`) functions cannot be payable, the only solution I could find was to call `router.sendMessage`, removing the wrapper function from `EquitoApp`.