### PR TITLE
fix: make `executeMessage` and `receiveMessage` functions payable

### DIFF
--- a/src/ECDSAVerifier.sol
+++ b/src/ECDSAVerifier.sol
@@ -83,6 +83,17 @@ contract ECDSAVerifier is IEquitoVerifier, IEquitoReceiver, IEquitoFees {
         router = IRouter(_router);
     }
 
+    /// @notice Verifies an `EquitoMessage` has been signed by a sufficient number of Validators.
+    /// @param message The `EquitoMessage` to verify.
+    /// @param proof The concatenated ECDSA signatures from the validators.
+    /// @return True if the message is verified successfully, otherwise false.
+    function verifyMessage(
+        EquitoMessage calldata message,
+        bytes calldata proof
+    ) external returns (bool) {
+        return this.verifySignatures(keccak256(abi.encode(messages[0])), proof);
+    }
+
     /// @notice Verifies that a set of `EquitoMessage` instances have been signed by a sufficient number of Validators.
     /// @param messages The array of `EquitoMessage` instances to verify.
     /// @param proof The concatenated ECDSA signatures from the validators.
@@ -116,7 +127,7 @@ contract ECDSAVerifier is IEquitoVerifier, IEquitoReceiver, IEquitoFees {
     function verifySignatures(
         bytes32 hash,
         bytes memory proof
-    ) external view override returns (bool) {
+    ) internal view returns (bool) {
         if (proof.length % 65 != 0) return false;
 
         uint256 validatorsLength = validators.length;

--- a/src/EquitoApp.sol
+++ b/src/EquitoApp.sol
@@ -33,6 +33,14 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
         _;
     }
 
+    /// @notice Modifier to restrict access to only to this contract.
+    /// @dev As internal functions can't be payable, this workaround is needed 
+    ///      to make the `_receiveMessageFrom` functions act like internal.
+    modifier onlySelf() {
+        if (msg.sender != address(this)) revert Errors.InvalidSender(msg.sender);
+        _;
+    }
+
     /// @notice Allows the owner to set the peer addresses for different chain IDs.
     /// @param chainIds The list of chain IDs.
     /// @param addresses The list of addresses corresponding to the chain IDs.
@@ -63,13 +71,13 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
     function receiveMessage(
         EquitoMessage calldata message,
         bytes calldata messageData
-    ) external override onlyRouter {
+    ) external payable override onlyRouter {
         bytes64 memory peerAddress = peers[message.sourceChainSelector];
      
         if (peerAddress.lower != message.sender.lower || peerAddress.upper != message.sender.upper) {
-            _receiveMessageFromNonPeer(message, messageData);
+            this._receiveMessageFromNonPeer{value: msg.value}(message, messageData);
         } else {
-            _receiveMessageFromPeer(message, messageData);
+            this._receiveMessageFromPeer{value: msg.value}(message, messageData);
         }
     }
 
@@ -79,7 +87,7 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
     function _receiveMessageFromPeer(
         EquitoMessage calldata message,
         bytes calldata messageData
-    ) internal virtual {}
+    ) external payable virtual onlySelf {}
 
     /// @notice The logic for receiving a cross-chain message from a non-peer.
     ///         The default implementation reverts the transaction.
@@ -88,7 +96,7 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
     function _receiveMessageFromNonPeer(
         EquitoMessage calldata message,
         bytes calldata messageData    
-    ) internal virtual {
+    ) external payable virtual onlySelf {
         revert Errors.InvalidMessageSender();
     }
 }

--- a/src/examples/CrossChainSwap.sol
+++ b/src/examples/CrossChainSwap.sol
@@ -103,7 +103,7 @@ contract CrossChainSwap is EquitoApp {
     function _receiveMessageFromPeer(
         EquitoMessage calldata message, 
         bytes calldata messageData
-    ) internal override {
+    ) external payable override {
         TokenAmount memory tokenAmount = abi.decode(
             messageData,
             (TokenAmount)

--- a/src/examples/PingPong.sol
+++ b/src/examples/PingPong.sol
@@ -8,26 +8,37 @@ import {bytes64, EquitoMessage, EquitoMessageLibrary} from "../libraries/EquitoM
 /// @title PingPong
 /// @notice This contract implements a simple ping-pong message exchange using the Equito cross-chain messaging protocol.
 contract PingPong is EquitoApp {
-
     /// @notice Event emitted when a ping message is sent.
     /// @param destinationChainSelector The identifier of the destination chain.
     /// @param messageHash The ping message hash.
-    event PingSent(uint256 indexed destinationChainSelector, bytes32 messageHash);
+    event PingSent(
+        uint256 indexed destinationChainSelector,
+        bytes32 messageHash
+    );
 
     /// @notice Event emitted when a ping message is received.
     /// @param sourceChainSelector The identifier of the source chain.
     /// @param messageHash The ping message hash.
-    event PingReceived(uint256 indexed sourceChainSelector, bytes32 messageHash);
+    event PingReceived(
+        uint256 indexed sourceChainSelector,
+        bytes32 messageHash
+    );
 
     /// @notice Event emitted when a pong message is sent.
     /// @param destinationChainSelector The identifier of the destination chain.
     /// @param messageHash The pong message hash.
-    event PongSent(uint256 indexed destinationChainSelector, bytes32 messageHash);
+    event PongSent(
+        uint256 indexed destinationChainSelector,
+        bytes32 messageHash
+    );
 
     /// @notice Event emitted when a pong message is received.
     /// @param sourceChainSelector The identifier of the source chain.
     /// @param messageHash The pong message hash.
-    event PongReceived(uint256 indexed sourceChainSelector, bytes32 messageHash);
+    event PongReceived(
+        uint256 indexed sourceChainSelector,
+        bytes32 messageHash
+    );
 
     /// @notice Thrown when attempting to set the router, but the router is already set.
     error RouterAlreadySet();
@@ -42,46 +53,54 @@ contract PingPong is EquitoApp {
     /// @notice Sends a ping message to the specified address on another chain.
     /// @param destinationChainSelector The identifier of the destination chain.
     /// @param message The ping message.
-    function sendPing(uint256 destinationChainSelector, string calldata message) external payable {
+    function sendPing(
+        uint256 destinationChainSelector,
+        string calldata message
+    ) external payable {
         bytes memory data = abi.encode("ping", message);
         bytes64 memory receiver = peers[destinationChainSelector];
 
         bytes32 messageHash = router.sendMessage{value: msg.value}(
-            receiver, 
-            destinationChainSelector, 
+            receiver,
+            destinationChainSelector,
             data
-            );
+        );
         emit PingSent(destinationChainSelector, messageHash);
     }
 
     /// @notice Receives a message from the router and handles it.
     /// @param message The Equito message received.
     /// @param messageData The data of the message received.
-    function _receiveMessageFromPeer(EquitoMessage calldata message, bytes calldata messageData) internal override {
-        (string memory messageType, string memory payload) = abi.decode(messageData, (string, string));
+    function _receiveMessageFromPeer(
+        EquitoMessage calldata message,
+        bytes calldata messageData
+    ) external payable override {
+        (string memory messageType, string memory payload) = abi.decode(
+            messageData,
+            (string, string)
+        );
 
         if (keccak256(bytes(messageType)) == keccak256(bytes("ping"))) {
-            emit PingReceived(message.sourceChainSelector, keccak256(abi.encode(message)));
-            sendPong(message.sourceChainSelector, payload);
+            emit PingReceived(
+                message.sourceChainSelector,
+                keccak256(abi.encode(message))
+            );
+
+            // send pong
+            bytes memory data = abi.encode("pong", payload);
+            bytes32 messageHash = router.sendMessage{value: msg.value}(
+                peers[message.sourceChainSelector],
+                message.sourceChainSelector,
+                data
+            );
+            emit PongSent(message.sourceChainSelector, messageHash);
         } else if (keccak256(bytes(messageType)) == keccak256(bytes("pong"))) {
-            emit PongReceived(message.sourceChainSelector, keccak256(abi.encode(message)));
+            emit PongReceived(
+                message.sourceChainSelector,
+                keccak256(abi.encode(message))
+            );
         } else {
             revert InvalidMessageType();
         }
-    }
-
-    /// @notice Sends a pong message in response to a received ping.
-    /// @param destinationChainSelector The identifier of the destination chain.
-    /// @param message The pong message.
-    function sendPong(uint256 destinationChainSelector, string memory message) internal {
-        bytes memory data = abi.encode("pong", message);
-        bytes64 memory receiver = peers[destinationChainSelector];
-
-        bytes32 messageHash = router.sendMessage{value: msg.value}(
-            receiver, 
-            destinationChainSelector, 
-            data
-        );
-        emit PongSent(destinationChainSelector, messageHash);
     }
 }

--- a/src/interfaces/IEquitoReceiver.sol
+++ b/src/interfaces/IEquitoReceiver.sol
@@ -10,5 +10,8 @@ interface IEquitoReceiver {
     /// @notice Receives a cross-chain message from the Router contract.
     /// @param message The Equito message received.
     /// @param messageData The data of the message.
-    function receiveMessage(EquitoMessage calldata message, bytes calldata messageData) external;
+    function receiveMessage(
+        EquitoMessage calldata message,
+        bytes calldata messageData
+    ) external payable;
 }

--- a/src/interfaces/IEquitoVerifier.sol
+++ b/src/interfaces/IEquitoVerifier.sol
@@ -7,6 +7,15 @@ import {EquitoMessage} from "../libraries/EquitoMessageLibrary.sol";
 /// @title IEquitoVerifier
 /// @notice Interface for the verifier contract used in the Equito protocol to verify cross-chain messages.
 interface IEquitoVerifier {
+    /// @notice Verifies an `EquitoMessage` using the provided proof.
+    /// @param message The `EquitoMessage` to verify.
+    /// @param proof The proof provided to verify the message.
+    /// @return True if the message is verified successfully, otherwise false.
+    function verifyMessage(
+        EquitoMessage calldata message,
+        bytes calldata proof
+    ) external returns (bool); 
+
     /// @notice Verifies a set of Equito messages using the provided proof.
     /// @param messages The array of Equito messages to verify.
     /// @param proof The proof provided to verify the messages.
@@ -15,13 +24,4 @@ interface IEquitoVerifier {
         EquitoMessage[] calldata messages,
         bytes calldata proof
     ) external returns (bool); 
-
-    /// @notice Verifies the signatures of a hashed message using the provided proof.
-    /// @param hash The hash of the message to verify.
-    /// @param proof The proof provided to verify the signatures.
-    /// @return True if the signatures are verified successfully, otherwise false.
-    function verifySignatures(
-        bytes32 hash,
-        bytes calldata proof
-    ) external returns (bool);
 }

--- a/src/interfaces/IRouter.sol
+++ b/src/interfaces/IRouter.sol
@@ -41,17 +41,17 @@ interface IRouter {
         bytes calldata data
     ) external payable returns (bytes32);
 
-    /// @notice Routes messages to the appropriate receiver contracts.
-    /// @param messages The list of messages to be delivered and executed.
-    /// @param messageData The data of the messages to be delivered and executed.
-    /// @param verifierIndex The index of the verifier used to verify the messages.
-    /// @param proof The proof provided by the verifier.
-    function deliverAndExecuteMessages(
-        EquitoMessage[] calldata messages,
-        bytes[] calldata messageData,
+    /// @notice Verify and execute a message with the appropriate receiver contract.
+    /// @param message The message to be executed.
+    /// @param messageData The data of the message to be executed.
+    /// @param verifierIndex The index of the verifier used to verify the message.
+    /// @param proof The proof to provide to the verifier.
+    function deliverAndExecuteMessage(
+        EquitoMessage calldata message,
+        bytes calldata messageData,
         uint256 verifierIndex,
         bytes calldata proof
-    ) external;
+    ) external payable;
 
     /// @notice Delivers messages to be stored for later execution.
     /// @param messages The list of messages to be delivered.
@@ -63,13 +63,13 @@ interface IRouter {
         bytes calldata proof
     ) external;
 
-    /// @notice Executes the stored messages.
-    /// @param messages The list of messages to be executed.
-    /// @param messageData The data of the messages to be executed.
-    function executeMessages(
-        EquitoMessage[] calldata messages,
-        bytes[] calldata messageData
-    ) external;
+    /// @notice Executes a stored message.
+    /// @param message The message to be executed.
+    /// @param messageData The data of the message to be executed.
+    function executeMessage(
+        EquitoMessage calldata message,
+        bytes calldata messageData
+    ) external payable;
 
     /// @notice Returns the chain selector of the current chain.
     function chainSelector() external view returns (uint256);

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -15,10 +15,6 @@ library Errors {
     /// @notice Thrown when the proof for verifying messages is invalid.
     error InvalidMessagesProof();
 
-    /// @notice Thrown when the proof for adding a new verifier is invalid.
-    /// @param verifier The address of the verifier that failed to be added.
-    error InvalidNewVerifierProof(address verifier);
-
     /// @notice Thrown when the verifier index provided is out of bounds.
     error InvalidVerifierIndex();
 
@@ -60,4 +56,7 @@ library Errors {
 
     /// @notice Thrown when attempting to set the router, but the router is already set.
     error RouterAlreadySet();
+
+    /// @notice Thrown when an invalid sender is calling a function.
+    error InvalidSender(address sender);
 }

--- a/test/CrossChainSwap.t.sol
+++ b/test/CrossChainSwap.t.sol
@@ -38,7 +38,12 @@ contract CrossChainSwapTest is Test {
         verifier = new MockVerifier();
         equitoFees = new MockEquitoFees();
         receiver = new MockReceiver();
-        router = new Router(1, address(verifier), address(equitoFees), EquitoMessageLibrary.addressToBytes64(equitoAddress));
+        router = new Router(
+            1,
+            address(verifier),
+            address(equitoFees),
+            EquitoMessageLibrary.addressToBytes64(equitoAddress)
+        );
         swap = new CrossChainSwap(address(router));
         token0 = new MockERC20("Token0", "TK0", 1_000_000 ether);
 
@@ -237,11 +242,12 @@ contract CrossChainSwapTest is Test {
         assertEq(aliceBalanceAfter, 0);
 
         uint256 bobBalanceBefore = token0.balanceOf(BOB);
-        EquitoMessage[] memory messages = new EquitoMessage[](1);
-        messages[0] = message;
-        bytes[] memory messageData = new bytes[](1);
-        messageData[0] = abi.encode(data);
-        router.deliverAndExecuteMessages(messages, messageData, 0, bytes("0"));
+        router.deliverAndExecuteMessage(
+            message,
+            abi.encode(data),
+            0,
+            bytes("0")
+        );
         uint256 bobBalanceAfter = token0.balanceOf(BOB);
         assertEq(bobBalanceBefore, 0);
         assertEq(bobBalanceAfter, 500);
@@ -309,11 +315,12 @@ contract CrossChainSwapTest is Test {
         assertEq(aliceBalanceAfter, 1_000);
 
         uint256 bobBalanceBefore = BOB.balance;
-        EquitoMessage[] memory messages = new EquitoMessage[](1);
-        messages[0] = message;
-        bytes[] memory messageData = new bytes[](1);
-        messageData[0] = abi.encode(data);
-        router.deliverAndExecuteMessages(messages, messageData, 0, bytes("0"));
+        router.deliverAndExecuteMessage(
+            message,
+            abi.encode(data),
+            0,
+            bytes("0")
+        );
         uint256 bobBalanceAfter = BOB.balance;
         assertEq(bobBalanceBefore, 0);
         assertEq(bobBalanceAfter, 2000);

--- a/test/ECDSAVerifier.t.sol
+++ b/test/ECDSAVerifier.t.sol
@@ -74,20 +74,18 @@ contract ECDSAVerifierTest is Test {
         (, uint256 baltatharSecret) = makeAddrAndKey("baltathar");
         (, uint256 charlethSecret) = makeAddrAndKey("charleth");
 
-        bytes[] memory messageData = new bytes[](1);
-        messageData[0] = abi.encode(bytes1(0x07));
+        bytes memory messageData = abi.encode(bytes1(0x07));
 
-        EquitoMessage[] memory messages = new EquitoMessage[](1);
-        messages[0] = EquitoMessage({
+        EquitoMessage memory message = EquitoMessage({
             blockNumber: 0,
             sourceChainSelector: 0,
             sender: EquitoMessageLibrary.addressToBytes64(equitoAddress),
             destinationChainSelector: 1,
             receiver: EquitoMessageLibrary.addressToBytes64(address(verifier)),
-            hashedData: keccak256(messageData[0])
+            hashedData: keccak256(messageData)
         });
 
-        bytes32 messageHash = keccak256(abi.encode(messages[0]));
+        bytes32 messageHash = keccak256(abi.encode(message));
 
         bytes memory proof = bytes.concat(
             signMessage(messageHash, charlethSecret),
@@ -96,7 +94,7 @@ contract ECDSAVerifierTest is Test {
         );
 
         vm.expectRevert(Errors.InvalidOperation.selector);
-        router.deliverAndExecuteMessages(messages, messageData, 0, proof);
+        router.deliverAndExecuteMessage(message, messageData, 0, proof);
     }
 
     /// @dev Tests the onlySovereign modifier with an invalid sender
@@ -144,7 +142,7 @@ contract ECDSAVerifierTest is Test {
     }
 
     /// @notice Tests the verification of a single message.
-    function testVerifyMessages() public {
+    function testVerifyMessage() public {
         (address alith, uint256 alithSecret) = makeAddrAndKey("alith");
         (, uint256 baltatharSecret) = makeAddrAndKey("baltathar");
         (, uint256 charlethSecret) = makeAddrAndKey("charleth");
@@ -169,7 +167,7 @@ contract ECDSAVerifierTest is Test {
     }
 
     /// @notice Tests the verification of a single message using verifyMessages.
-    function testVerifyMessages() public {
+    function testVerifyMessagesSingleMessage() public {
         (address alith, uint256 alithSecret) = makeAddrAndKey("alith");
         (, uint256 baltatharSecret) = makeAddrAndKey("baltathar");
         (, uint256 charlethSecret) = makeAddrAndKey("charleth");
@@ -194,7 +192,7 @@ contract ECDSAVerifierTest is Test {
         console.log(verifier.verifyMessages(messages, proof));
     }
 
-    function testVerifyMultipleMessages() public {
+    function testVerifyMessagesMultipleMessages() public {
         (address alith, uint256 alithSecret) = makeAddrAndKey("alith");
         (address baltathar, uint256 baltatharSecret) = makeAddrAndKey(
             "baltathar"
@@ -251,26 +249,6 @@ contract ECDSAVerifierTest is Test {
         );
 
         console.log(verifier.verifyMessages(messages, proof));
-    }
-
-    /// @notice Tests the updating of validators.
-    function testUpdateValidators() public {
-        (address charleth, ) = makeAddrAndKey("charleth");
-
-        uint256 session = verifier.session();
-
-        address[] memory validators = new address[](1);
-        validators[0] = charleth;
-
-        verifier.updateValidators(validators);
-
-        assert(verifier.validators(0) == charleth);
-        assertEq(verifier.session(), session + 1);
-
-        vm.expectRevert();
-        console.log(verifier.validators(1));
-
-        console.log("Validators updated successfully!");
     }
 
     /// @notice Tests the verification of empty messages, which should fail.
@@ -537,20 +515,22 @@ contract ECDSAVerifierTest is Test {
         address[] memory validators = new address[](1);
         validators[0] = charleth;
 
-        bytes[] memory messageData = new bytes[](1);
-        messageData[0] = abi.encode(bytes1(0x01), session, validators);
+        bytes memory messageData = abi.encode(
+            bytes1(0x01),
+            session,
+            validators
+        );
 
-        EquitoMessage[] memory messages = new EquitoMessage[](1);
-        messages[0] = EquitoMessage({
+        EquitoMessage memory message = EquitoMessage({
             blockNumber: 0,
             sourceChainSelector: 0,
             sender: EquitoMessageLibrary.addressToBytes64(equitoAddress),
             destinationChainSelector: 1,
             receiver: EquitoMessageLibrary.addressToBytes64(address(verifier)),
-            hashedData: keccak256(messageData[0])
+            hashedData: keccak256(messageData)
         });
 
-        bytes32 messageHash = keccak256(abi.encode(messages[0]));
+        bytes32 messageHash = keccak256(abi.encode(message));
 
         bytes memory proof = bytes.concat(
             signMessage(messageHash, charlethSecret),
@@ -560,7 +540,7 @@ contract ECDSAVerifierTest is Test {
 
         vm.expectEmit(true, true, true, true);
         emit ValidatorSetUpdated();
-        router.deliverAndExecuteMessages(messages, messageData, 0, proof);
+        router.deliverAndExecuteMessage(message, messageData, 0, proof);
 
         assert(verifier.validators(0) == charleth);
         assertEq(verifier.session(), session + 1);
@@ -576,20 +556,22 @@ contract ECDSAVerifierTest is Test {
 
         address[] memory validators = new address[](1);
 
-        bytes[] memory messageData = new bytes[](1);
-        messageData[0] = abi.encode(bytes1(0x01), session + 1, validators);
+        bytes memory messageData = abi.encode(
+            bytes1(0x01),
+            session + 1,
+            validators
+        );
 
-        EquitoMessage[] memory messages = new EquitoMessage[](1);
-        messages[0] = EquitoMessage({
+        EquitoMessage memory message = EquitoMessage({
             blockNumber: 0,
             sourceChainSelector: 0,
             sender: EquitoMessageLibrary.addressToBytes64(equitoAddress),
             destinationChainSelector: 1,
             receiver: EquitoMessageLibrary.addressToBytes64(address(verifier)),
-            hashedData: keccak256(messageData[0])
+            hashedData: keccak256(messageData)
         });
 
-        bytes32 messageHash = keccak256(abi.encode(messages[0]));
+        bytes32 messageHash = keccak256(abi.encode(message));
 
         bytes memory proof = bytes.concat(
             signMessage(messageHash, charlethSecret),
@@ -598,7 +580,7 @@ contract ECDSAVerifierTest is Test {
         );
 
         vm.expectRevert(Errors.SessionIdMismatch.selector);
-        router.deliverAndExecuteMessages(messages, messageData, 0, proof);
+        router.deliverAndExecuteMessage(message, messageData, 0, proof);
     }
 
     /// @notice Tests the receive message with set message cost usd command.
@@ -619,20 +601,18 @@ contract ECDSAVerifierTest is Test {
         (, uint256 baltatharSecret) = makeAddrAndKey("baltathar");
         (, uint256 charlethSecret) = makeAddrAndKey("charleth");
 
-        bytes[] memory messageData = new bytes[](1);
-        messageData[0] = abi.encode(bytes1(0x02), 0.5 ether);
+        bytes memory messageData = abi.encode(bytes1(0x02), 0.5 ether);
 
-        EquitoMessage[] memory messages = new EquitoMessage[](1);
-        messages[0] = EquitoMessage({
+        EquitoMessage memory message = EquitoMessage({
             blockNumber: 0,
             sourceChainSelector: 0,
             sender: EquitoMessageLibrary.addressToBytes64(equitoAddress),
             destinationChainSelector: 1,
             receiver: EquitoMessageLibrary.addressToBytes64(address(verifier)),
-            hashedData: keccak256(messageData[0])
+            hashedData: keccak256(messageData)
         });
 
-        bytes32 messageHash = keccak256(abi.encode(messages[0]));
+        bytes32 messageHash = keccak256(abi.encode(message));
 
         bytes memory proof = bytes.concat(
             signMessage(messageHash, charlethSecret),
@@ -642,7 +622,7 @@ contract ECDSAVerifierTest is Test {
 
         vm.expectEmit(true, true, true, true);
         emit MessageCostUsdSet(0.5 ether);
-        router.deliverAndExecuteMessages(messages, messageData, 0, proof);
+        router.deliverAndExecuteMessage(message, messageData, 0, proof);
 
         assertEq(
             verifier.messageCostUsd(),
@@ -673,24 +653,22 @@ contract ECDSAVerifierTest is Test {
         (, uint256 baltatharSecret) = makeAddrAndKey("baltathar");
         (, uint256 charlethSecret) = makeAddrAndKey("charleth");
 
-        bytes[] memory messageData = new bytes[](1);
-        messageData[0] = abi.encode(
+        bytes memory messageData = abi.encode(
             bytes1(0x03),
             liquidityProvider,
             transferAmount
         );
 
-        EquitoMessage[] memory messages = new EquitoMessage[](1);
-        messages[0] = EquitoMessage({
+        EquitoMessage memory message = EquitoMessage({
             blockNumber: 0,
             sourceChainSelector: 0,
             sender: EquitoMessageLibrary.addressToBytes64(equitoAddress),
             destinationChainSelector: 1,
             receiver: EquitoMessageLibrary.addressToBytes64(address(verifier)),
-            hashedData: keccak256(messageData[0])
+            hashedData: keccak256(messageData)
         });
 
-        bytes32 messageHash = keccak256(abi.encode(messages[0]));
+        bytes32 messageHash = keccak256(abi.encode(message));
         bytes memory proof = bytes.concat(
             signMessage(messageHash, charlethSecret),
             signMessage(messageHash, alithSecret),
@@ -700,7 +678,7 @@ contract ECDSAVerifierTest is Test {
         vm.prank(address(verifier));
         vm.expectEmit(true, true, true, true);
         emit FeesTransferred(liquidityProvider, session, transferAmount);
-        router.deliverAndExecuteMessages(messages, messageData, 0, proof);
+        router.deliverAndExecuteMessage(message, messageData, 0, proof);
 
         assertEq(
             address(verifier).balance,
@@ -720,20 +698,18 @@ contract ECDSAVerifierTest is Test {
         (, uint256 baltatharSecret) = makeAddrAndKey("baltathar");
         (, uint256 charlethSecret) = makeAddrAndKey("charleth");
 
-        bytes[] memory messageData = new bytes[](1);
-        messageData[0] = abi.encode(bytes1(0x04), BOB);
+        bytes memory messageData = abi.encode(bytes1(0x04), BOB);
 
-        EquitoMessage[] memory messages = new EquitoMessage[](1);
-        messages[0] = EquitoMessage({
+        EquitoMessage memory message = EquitoMessage({
             blockNumber: 0,
             sourceChainSelector: 0,
             sender: EquitoMessageLibrary.addressToBytes64(equitoAddress),
             destinationChainSelector: 1,
             receiver: EquitoMessageLibrary.addressToBytes64(address(verifier)),
-            hashedData: keccak256(messageData[0])
+            hashedData: keccak256(messageData)
         });
 
-        bytes32 messageHash = keccak256(abi.encode(messages[0]));
+        bytes32 messageHash = keccak256(abi.encode(message));
 
         bytes memory proof = bytes.concat(
             signMessage(messageHash, charlethSecret),
@@ -743,7 +719,7 @@ contract ECDSAVerifierTest is Test {
 
         vm.expectEmit(true, true, true, true);
         emit NoFeeAddressAdded(BOB);
-        router.deliverAndExecuteMessages(messages, messageData, 0, proof);
+        router.deliverAndExecuteMessage(message, messageData, 0, proof);
 
         assertEq(verifier.noFee(BOB), true, "No fee address not set correctly");
     }
@@ -759,20 +735,18 @@ contract ECDSAVerifierTest is Test {
         (, uint256 baltatharSecret) = makeAddrAndKey("baltathar");
         (, uint256 charlethSecret) = makeAddrAndKey("charleth");
 
-        bytes[] memory messageData = new bytes[](1);
-        messageData[0] = abi.encode(bytes1(0x05), BOB);
+        bytes memory messageData = abi.encode(bytes1(0x05), BOB);
 
-        EquitoMessage[] memory messages = new EquitoMessage[](1);
-        messages[0] = EquitoMessage({
+        EquitoMessage memory message = EquitoMessage({
             blockNumber: 0,
             sourceChainSelector: 0,
             sender: EquitoMessageLibrary.addressToBytes64(equitoAddress),
             destinationChainSelector: 1,
             receiver: EquitoMessageLibrary.addressToBytes64(address(verifier)),
-            hashedData: keccak256(messageData[0])
+            hashedData: keccak256(messageData)
         });
 
-        bytes32 messageHash = keccak256(abi.encode(messages[0]));
+        bytes32 messageHash = keccak256(abi.encode(message));
 
         bytes memory proof = bytes.concat(
             signMessage(messageHash, charlethSecret),
@@ -782,7 +756,7 @@ contract ECDSAVerifierTest is Test {
 
         vm.expectEmit(true, true, true, true);
         emit NoFeeAddressRemoved(BOB);
-        router.deliverAndExecuteMessages(messages, messageData, 0, proof);
+        router.deliverAndExecuteMessage(message, messageData, 0, proof);
 
         assertEq(verifier.noFee(BOB), false, "No fee address not removed");
     }

--- a/test/EquitoApp.t.sol
+++ b/test/EquitoApp.t.sol
@@ -26,7 +26,10 @@ contract EquitoAppTest is Test {
     function setUp() public {
         vm.startPrank(OWNER);
         verifier = new MockVerifier();
-        router = new MockRouter(1, address(verifier), address(verifier), EquitoMessageLibrary.addressToBytes64(equitoAddress));
+        router = new MockRouter(
+            1,
+            EquitoMessageLibrary.addressToBytes64(equitoAddress)
+        );
         app = new MockEquitoApp(address(router));
         vm.stopPrank();
     }
@@ -150,5 +153,28 @@ contract EquitoAppTest is Test {
         vm.prank(address(router));
         vm.expectRevert(Errors.InvalidMessageSender.selector);
         app.receiveMessage(message, hex"123456");
+    }
+
+    function testInvalidSenderFails() public {
+        EquitoMessage memory message = EquitoMessage({
+            blockNumber: 1,
+            sourceChainSelector: 1,
+            sender: EquitoMessageLibrary.addressToBytes64(BOB),
+            destinationChainSelector: 2,
+            receiver: EquitoMessageLibrary.addressToBytes64(address(app)),
+            hashedData: keccak256(hex"123456")
+        });
+
+        vm.prank(ALICE);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.InvalidSender.selector, ALICE)
+        );
+        app._receiveMessageFromPeer(message, hex"123456");
+
+        vm.prank(BOB);
+        vm.expectRevert(
+            abi.encodeWithSelector(Errors.InvalidSender.selector, BOB)
+        );
+        app._receiveMessageFromNonPeer(message, hex"123456");
     }
 }

--- a/test/EquitoFees.t.sol
+++ b/test/EquitoFees.t.sol
@@ -28,7 +28,7 @@ contract EquitoFeesTest is Test {
         equitoFees = new MockEquitoFees();
         vm.stopPrank();
     }
-    
+
     /// @notice Test that the initial fee is set correctly.
     function testInitialFee() public {
         uint256 fee = equitoFees.getFee(ALICE);

--- a/test/mock/MockReceiver.sol
+++ b/test/mock/MockReceiver.sol
@@ -12,7 +12,7 @@ contract MockReceiver is IEquitoReceiver {
     function receiveMessage(
         EquitoMessage calldata _message, 
         bytes calldata _messageData
-    ) external override {
+    ) external payable override {
         message = _message;
         messageData = _messageData;
     }

--- a/test/mock/MockRouter.sol
+++ b/test/mock/MockRouter.sol
@@ -4,28 +4,16 @@ pragma solidity ^0.8.23;
 
 import {IRouter} from "../../src/Router.sol";
 import {IEquitoFees} from "../../src/interfaces/IEquitoFees.sol";
-import {IEquitoReceiver} from "../../src/interfaces/IEquitoReceiver.sol";
 import {bytes64, EquitoMessage} from "../../src/libraries/EquitoMessageLibrary.sol";
 import {IEquitoVerifier} from "../../src/interfaces/IEquitoVerifier.sol";
 import {Test, console} from "forge-std/Test.sol";
 
-contract MockRouter is IRouter, IEquitoReceiver {
+contract MockRouter is IRouter {
     uint256 public immutable chainSelector;
-
     bytes64 public equitoAddress;
 
-    IEquitoVerifier[] public verifiers;
-
-    mapping(bytes32 => bool) public isDuplicateMessage;
-
-    IEquitoFees public equitoFees;
-
-    constructor(uint256 _chainSelector, address _initialVerifier, address _equitoFees, bytes64 memory _equitoAddress) {
+    constructor(uint256 _chainSelector, bytes64 memory _equitoAddress) {
         chainSelector = _chainSelector;
-        verifiers.push(IEquitoVerifier(_initialVerifier));
-
-        equitoFees = IEquitoFees(_equitoFees);
-
         equitoAddress = _equitoAddress;
     }
 
@@ -37,12 +25,12 @@ contract MockRouter is IRouter, IEquitoReceiver {
         return keccak256(abi.encode(receiver, destinationChainSelector, data));
     }
 
-    function deliverAndExecuteMessages(
-        EquitoMessage[] calldata messages,
-        bytes[] calldata messageData,
+    function deliverAndExecuteMessage(
+        EquitoMessage calldata message,
+        bytes calldata messageData,
         uint256 verifierIndex,
         bytes calldata proof
-    ) external {}
+    ) external payable {}
 
     function deliverMessages(
         EquitoMessage[] calldata messages,
@@ -50,25 +38,12 @@ contract MockRouter is IRouter, IEquitoReceiver {
         bytes calldata proof
     ) external {}
 
-    function executeMessages(
-        EquitoMessage[] calldata messages,
-        bytes[] calldata messageData
-    ) external {}
-
-    function receiveMessage(
-        EquitoMessage calldata message,
+    function executeMessage(
+        EquitoMessage calldata messages,
         bytes calldata messageData
-    ) external override {}
+    ) external payable {}
 
-    function _addVerifier(
-        address _newVerifier,
-        uint256 verifierIndex,
-        bytes calldata proof
-    ) internal {}
-
-    function _setEquitoFees(
-        address _equitoFees
-    ) internal {}
-
-    function _setEquitoAddress(bytes64 memory _equitoAddress) internal {}
+    function _setEquitoAddress(bytes64 memory _equitoAddress) internal {
+        equitoAddress = _equitoAddress;
+    }
 }

--- a/test/mock/MockVerifier.sol
+++ b/test/mock/MockVerifier.sol
@@ -8,7 +8,7 @@ import {IEquitoVerifier} from "../../src/interfaces/IEquitoVerifier.sol";
 /// Mock Verifier that returns true for all non-empty proofs.
 contract MockVerifier is IEquitoVerifier {
     function verifyMessage(
-        EquitoMessage[] calldata messages,
+        EquitoMessage calldata message,
         bytes calldata proof
     ) external override returns (bool) {
         return proof.length > 0;

--- a/test/mock/MockVerifier.sol
+++ b/test/mock/MockVerifier.sol
@@ -7,15 +7,15 @@ import {IEquitoVerifier} from "../../src/interfaces/IEquitoVerifier.sol";
 
 /// Mock Verifier that returns true for all non-empty proofs.
 contract MockVerifier is IEquitoVerifier {
-    function verifyMessages(
+    function verifyMessage(
         EquitoMessage[] calldata messages,
         bytes calldata proof
     ) external override returns (bool) {
         return proof.length > 0;
     }
 
-    function verifySignatures(
-        bytes32 hash,
+    function verifyMessages(
+        EquitoMessage[] calldata messages,
         bytes calldata proof
     ) external override returns (bool) {
         return proof.length > 0;


### PR DESCRIPTION
added `verifyMessage` to Verifier trait
execute one message at a time
restore PingPong functionality