### PR TITLE
fix: internal `_receiveMessage` functions

### DIFF
--- a/src/EquitoApp.sol
+++ b/src/EquitoApp.sol
@@ -33,14 +33,6 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
         _;
     }
 
-    /// @notice Modifier to restrict access to only to this contract.
-    /// @dev As internal functions can't be payable, this workaround is needed 
-    ///      to make the `_receiveMessageFrom` functions act like internal.
-    modifier onlySelf() {
-        if (msg.sender != address(this)) revert Errors.InvalidSender(msg.sender);
-        _;
-    }
-
     /// @notice Allows the owner to set the peer addresses for different chain IDs.
     /// @param chainIds The list of chain IDs.
     /// @param addresses The list of addresses corresponding to the chain IDs.
@@ -75,9 +67,9 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
         bytes64 memory peerAddress = peers[message.sourceChainSelector];
      
         if (peerAddress.lower != message.sender.lower || peerAddress.upper != message.sender.upper) {
-            this._receiveMessageFromNonPeer{value: msg.value}(message, messageData);
+            _receiveMessageFromNonPeer(message, messageData);
         } else {
-            this._receiveMessageFromPeer{value: msg.value}(message, messageData);
+            _receiveMessageFromPeer(message, messageData);
         }
     }
 
@@ -87,7 +79,7 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
     function _receiveMessageFromPeer(
         EquitoMessage calldata message,
         bytes calldata messageData
-    ) external payable virtual onlySelf {}
+    ) internal virtual {}
 
     /// @notice The logic for receiving a cross-chain message from a non-peer.
     ///         The default implementation reverts the transaction.
@@ -96,7 +88,7 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
     function _receiveMessageFromNonPeer(
         EquitoMessage calldata message,
         bytes calldata messageData    
-    ) external payable virtual onlySelf {
+    ) internal virtual {
         revert Errors.InvalidMessageSender();
     }
 }

--- a/src/EquitoERC20.sol
+++ b/src/EquitoERC20.sol
@@ -49,7 +49,7 @@ contract EquitoERC20 is EquitoApp, ERC20 {
     function _receiveMessageFromPeer(
         EquitoMessage calldata message,
         bytes calldata messageData
-    ) external payable override {
+    ) internal override {
         (bytes64 memory receiver, uint256 amount) = abi.decode(
             messageData,
             (bytes64, uint256)

--- a/src/examples/CrossChainSwap.sol
+++ b/src/examples/CrossChainSwap.sol
@@ -103,7 +103,7 @@ contract CrossChainSwap is EquitoApp {
     function _receiveMessageFromPeer(
         EquitoMessage calldata message, 
         bytes calldata messageData
-    ) external payable override {
+    ) internal override {
         TokenAmount memory tokenAmount = abi.decode(
             messageData,
             (TokenAmount)

--- a/src/examples/PingPong.sol
+++ b/src/examples/PingPong.sol
@@ -74,7 +74,7 @@ contract PingPong is EquitoApp {
     function _receiveMessageFromPeer(
         EquitoMessage calldata message,
         bytes calldata messageData
-    ) external payable override {
+    ) internal override {
         (string memory messageType, string memory payload) = abi.decode(
             messageData,
             (string, string)

--- a/test/EquitoApp.t.sol
+++ b/test/EquitoApp.t.sol
@@ -155,28 +155,4 @@ contract EquitoAppTest is Test {
         app.receiveMessage(message, hex"123456");
     }
 
-    /// @dev Tests the `_receiveMessage` functions fail when the sender address is not the actual contract.
-    ///      This ensures the overrides keep the `onlySelf` modifier.
-    function testInvalidSenderFails() public {
-        EquitoMessage memory message = EquitoMessage({
-            blockNumber: 1,
-            sourceChainSelector: 1,
-            sender: EquitoMessageLibrary.addressToBytes64(BOB),
-            destinationChainSelector: 2,
-            receiver: EquitoMessageLibrary.addressToBytes64(address(app)),
-            hashedData: keccak256(hex"123456")
-        });
-
-        vm.prank(ALICE);
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.InvalidSender.selector, ALICE)
-        );
-        app._receiveMessageFromPeer(message, hex"123456");
-
-        vm.prank(BOB);
-        vm.expectRevert(
-            abi.encodeWithSelector(Errors.InvalidSender.selector, BOB)
-        );
-        app._receiveMessageFromNonPeer(message, hex"123456");
-    }
 }

--- a/test/PingPong.t.sol
+++ b/test/PingPong.t.sol
@@ -111,6 +111,8 @@ contract PingPongTest is Test {
         messages[0] = message;
         router.deliverMessages(messages, 0, abi.encode(1));
 
+        uint256 feeContractBalance = address(fees).balance;
+
         uint256 fee = router.getFee(address(pingPong));
 
         vm.expectEmit(address(pingPong));
@@ -133,6 +135,8 @@ contract PingPongTest is Test {
 
         vm.prank(address(ALICE));
         router.executeMessage{value: fee}(message, messageData);
+
+        assertEq(address(fees).balance, feeContractBalance + fee);
     }
 
     function testReceivePong() public {


### PR DESCRIPTION
looks like internal function can access `msg.value` if called from an external function.
thanks @k-gunjan 