### PR TITLE
EquitoApp: `getPeer` function

### DIFF
--- a/src/EquitoApp.sol
+++ b/src/EquitoApp.sol
@@ -55,6 +55,20 @@ abstract contract EquitoApp is IEquitoReceiver, Ownable {
         }
     }
 
+    /// @notice Returns the peer address for a given chain selector.
+    /// @param chainSelector The chain selector for which the peer address is requested.
+    /// @return The peer address for the given chain selector.
+    /// @dev Throws an error if the chain selector is not found in the mapping.
+    function getPeer(
+        uint256 chainSelector
+    ) public view returns (bytes64 memory) {
+        bytes64 memory peerAddress = peers[chainSelector];
+        if (peerAddress.lower == 0x00 && peerAddress.upper == 0x00) {
+            revert Errors.InvalidPeer(chainSelector);
+        }
+        return peerAddress;
+    }
+
     /// @notice Receives a cross-chain message from the Router Contract.
     ///         It is a wrapper function for the `_receiveMessage` functions, that need to be overridden.
     ///         Only the Router Contract is allowed to call this function.

--- a/src/EquitoERC20.sol
+++ b/src/EquitoERC20.sol
@@ -36,7 +36,7 @@ contract EquitoERC20 is EquitoApp, ERC20 {
         _burn(msg.sender, amount);
         bytes memory data = abi.encode(receiver, amount);
         router.sendMessage{value: msg.value}(
-            peers[destinationChainSelector],
+            getPeer(destinationChainSelector),
             destinationChainSelector,
             data
         );

--- a/src/examples/CrossChainSwap.sol
+++ b/src/examples/CrossChainSwap.sol
@@ -209,7 +209,7 @@ contract CrossChainSwap is EquitoApp {
 
         // Send the message through the router and store the returned message ID
         messageHash = router.sendMessage{value: fee}(
-            peers[destinationChainSelector],
+            getPeer(destinationChainSelector),
             destinationChainSelector,
             abi.encode(tokenAmount)
         );

--- a/src/examples/HelloEquito.sol
+++ b/src/examples/HelloEquito.sol
@@ -35,15 +35,10 @@ contract HelloEquito is EquitoApp {
     /// @notice Sends a hello message to the peer address on the specified chain.
     /// @param destinationChainSelector The identifier of the destination chain.
     function sendMessage(uint256 destinationChainSelector) external payable {
-        bytes64 memory receiver = peers[destinationChainSelector];
-        if (receiver.lower == 0x00 && receiver.upper == 0x00) {
-            revert("HelloEquito: invalid destination chain selector");
-        }
-
         bytes memory data = abi.encode("Hello, Equito!");
 
         bytes32 messageHash = router.sendMessage{value: msg.value}(
-            receiver,
+            getPeer(destinationChainSelector),
             destinationChainSelector,
             data
         );

--- a/src/examples/PingPong.sol
+++ b/src/examples/PingPong.sol
@@ -58,10 +58,9 @@ contract PingPong is EquitoApp {
         string calldata message
     ) external payable {
         bytes memory data = abi.encode("ping", message);
-        bytes64 memory receiver = peers[destinationChainSelector];
 
         bytes32 messageHash = router.sendMessage{value: msg.value}(
-            receiver,
+            getPeer(destinationChainSelector),
             destinationChainSelector,
             data
         );
@@ -89,7 +88,7 @@ contract PingPong is EquitoApp {
             // send pong
             bytes memory data = abi.encode("pong", payload);
             bytes32 messageHash = router.sendMessage{value: msg.value}(
-                peers[message.sourceChainSelector],
+                getPeer(message.sourceChainSelector),
                 message.sourceChainSelector,
                 data
             );

--- a/src/libraries/Errors.sol
+++ b/src/libraries/Errors.sol
@@ -62,4 +62,8 @@ library Errors {
 
     /// @notice Thrown when the provided session ID does not match the current session.
     error InvalidSessionId();
+
+    /// @notice Thrown when a Peer address is not found in the mapping, given a chain selector.
+    /// @param chainSelector The chain selector for which the peer address is requested.
+    error InvalidPeer(uint256 chainSelector);
 }

--- a/test/EquitoERC20.t.sol
+++ b/test/EquitoERC20.t.sol
@@ -20,9 +20,6 @@ contract EquitoERC20Test is Test {
     address constant BOB = address(0xB0B);
     address equitoAddress = address(0x45717569746f);
 
-    uint256 public sourceChainSelector = 1;
-    uint256 public destinationChainSelector = 2;
-
     function setUp() public {
         vm.startPrank(OWNER);
         verifier = new MockVerifier();
@@ -34,6 +31,14 @@ contract EquitoERC20Test is Test {
             EquitoMessageLibrary.addressToBytes64(equitoAddress)
         );
         token = new EquitoERC20(address(router), "Equito Token", "EQI", 1000);
+        
+        uint256[] memory chainSelectors = new uint256[](1);
+        chainSelectors[0] = 1;
+
+        bytes64[] memory addresses = new bytes64[](1);
+        addresses[0] = EquitoMessageLibrary.addressToBytes64(address(token));
+
+        token.setPeers(chainSelectors, addresses);
 
         // Mint some tokens for testing
         token.transfer(ALICE, 100);
@@ -55,7 +60,7 @@ contract EquitoERC20Test is Test {
         vm.deal(ALICE, 0.1 ether);
         token.crossChainTransfer{value: 0.1 ether}(
             receiver,
-            destinationChainSelector,
+            1,
             amount
         );
 
@@ -65,19 +70,11 @@ contract EquitoERC20Test is Test {
     function testReceiveToken() public {
         uint256 amount = 10;
 
-        // Set the peer address in the contract
-        vm.prank(OWNER);
-        uint256[] memory chainSelectors = new uint256[](1);
-        chainSelectors[0] = destinationChainSelector;
-        bytes64[] memory addresses = new bytes64[](1);
-        addresses[0] = EquitoMessageLibrary.addressToBytes64(address(token));
-        token.setPeers(chainSelectors, addresses);
-
         EquitoMessage memory message = EquitoMessage({
             blockNumber: block.number,
-            sourceChainSelector: destinationChainSelector,
+            sourceChainSelector: 1,
             sender: EquitoMessageLibrary.addressToBytes64(address(token)),
-            destinationChainSelector: sourceChainSelector,
+            destinationChainSelector: 1,
             receiver: EquitoMessageLibrary.addressToBytes64(address(token)),
             hashedData: keccak256(
                 abi.encode(EquitoMessageLibrary.addressToBytes64(BOB), amount)


### PR DESCRIPTION
Improve development experience by adding a function that returns the appropriate peer and reverts when the peer is not set, avoiding explicit checks and situations where a message might be mistakenly sent to the zero-address of an invalid chain.